### PR TITLE
Add max request size middleware.

### DIFF
--- a/RobustApiTemplate/Common/Constants.cs
+++ b/RobustApiTemplate/Common/Constants.cs
@@ -1,0 +1,6 @@
+﻿namespace RobustApiTemplate.Common;
+
+public static class Constants
+{
+    public const string CORRELATION_ID_HEADER = "X-Correlation-ID";
+}

--- a/RobustApiTemplate/Common/ExtensionMethods.cs
+++ b/RobustApiTemplate/Common/ExtensionMethods.cs
@@ -1,0 +1,20 @@
+﻿namespace RobustApiTemplate.Common;
+
+public static class ExtensionMethods
+{
+    public static string GetOrSetCorrelationId(this HttpContext context)
+    {
+        if (context.Request.Headers.TryGetValue(Constants.CORRELATION_ID_HEADER, out var correlationId))
+        {
+            if (!string.IsNullOrEmpty(correlationId))
+            {
+                return correlationId.ToString();
+            }
+        }
+
+        // Optionally, generate a new correlation ID if not present
+        var newCorrelationId = Guid.NewGuid().ToString();
+        context.Request.Headers[Constants.CORRELATION_ID_HEADER] = newCorrelationId;
+        return newCorrelationId;
+    }
+}

--- a/RobustApiTemplate/Controllers/EmployeeController.cs
+++ b/RobustApiTemplate/Controllers/EmployeeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using RobustApiTemplate.Engine.Models;
 using RobustApiTemplate.Engine.Services;
 

--- a/RobustApiTemplate/Middleware/CorrelationIdMiddleware.cs
+++ b/RobustApiTemplate/Middleware/CorrelationIdMiddleware.cs
@@ -1,0 +1,22 @@
+﻿using RobustApiTemplate.Common;
+
+namespace RobustApiTemplate.Middleware;
+
+/// <summary>
+/// Middleware to generate a CorrelationId for each request.
+/// This CorrelationId is used to track a request through the system.
+/// </summary>
+/// <param name="next">Next RequestDelegate middleware</param>
+public class CorrelationIdMiddleware(RequestDelegate next)
+{
+    private readonly RequestDelegate _next = next;
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        // This will add a CorrelationId to the request headers if not present
+        context.GetOrSetCorrelationId();
+
+        // Proceed with the next middleware
+        await _next(context);
+    }
+}

--- a/RobustApiTemplate/Middleware/MaxRequestSizeMiddleware.cs
+++ b/RobustApiTemplate/Middleware/MaxRequestSizeMiddleware.cs
@@ -1,0 +1,65 @@
+﻿using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using RobustApiTemplate.Common;
+using RobustApiTemplate.Models;
+
+namespace RobustApiTemplate.Middleware;
+
+public class MaxRequestSizeMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly IConfiguration _configuration;
+    private readonly long _defaultMaxSizeInBytes;
+
+    public MaxRequestSizeMiddleware(RequestDelegate next, IConfiguration configuration)
+    {
+        _next = next;
+        _configuration = configuration;
+        _defaultMaxSizeInBytes =
+            _configuration.GetValue<long>("RequestSizeLimits:DefaultMaxSizeInBytes", 1024 * 1024); // 1 MB default
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var endpoint = context.GetEndpoint();
+
+        if (endpoint != null)
+        {
+            var controllerActionDescriptor =
+                endpoint.Metadata.GetMetadata<ControllerActionDescriptor>();
+
+            if (controllerActionDescriptor != null)
+            {
+                // Build the key for endpoint-specific size limits
+                var controllerName = controllerActionDescriptor.ControllerName;
+                var actionName = controllerActionDescriptor.ActionName;
+                var endpointKey = $"RequestSizeLimits:Endpoints:{controllerName}.{actionName}";
+
+                // Retrieve the max size from configuration, fallback to default if not found
+                long maxSizeInBytes = _configuration.GetValue<long?>(endpointKey) ?? _defaultMaxSizeInBytes;
+
+                // Check the request size if the Content-Length header is present
+                if (context.Request.ContentLength > maxSizeInBytes)
+                {
+                    var errorResponse = new ErrorResponse
+                    {
+                        CorrelationId = context.GetOrSetCorrelationId(),
+                        StatusCode = StatusCodes.Status413PayloadTooLarge,
+                        Message = "Request size exceeds the allowed limit.",
+                        Details = [$"The request size was {context.Request.ContentLength}, which exceeds the allowed limit of {maxSizeInBytes} bytes."]
+                    };
+
+                    context.Response.StatusCode = StatusCodes.Status413PayloadTooLarge;
+                    context.Response.ContentType = "application/json";
+
+                    var errorResponseJson = JsonSerializer.Serialize(errorResponse);
+                    await context.Response.WriteAsync(errorResponseJson);
+
+                    return;
+                }
+            }
+        }
+
+        await _next(context);
+    }
+}

--- a/RobustApiTemplate/Models/ErrorResponse.cs
+++ b/RobustApiTemplate/Models/ErrorResponse.cs
@@ -1,0 +1,9 @@
+﻿namespace RobustApiTemplate.Models;
+
+public class ErrorResponse
+{
+    public string CorrelationId { get; set; } = string.Empty;
+    public int StatusCode { get; set; }
+    public string Message { get; set; } = string.Empty;
+    public List<string> Details { get; set; } = [];
+}

--- a/RobustApiTemplate/Program.cs
+++ b/RobustApiTemplate/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.ResponseCompression;
 using RobustApiTemplate.Engine.Services;
+using RobustApiTemplate.Middleware;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -40,7 +41,17 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
+app.UseAuthentication();
 app.UseAuthorization();
+
+// Add custom middleware to the request pipeline
+
+// Add CorrelationIdMiddleware, to make a unique identifier for each request,
+// that is available to all downstream components.
+app.UseMiddleware<CorrelationIdMiddleware>();
+
+// Add custom middleware to enforce maximum request size
+app.UseMiddleware<MaxRequestSizeMiddleware>();
 
 app.MapControllers();
 

--- a/RobustApiTemplate/appsettings.json
+++ b/RobustApiTemplate/appsettings.json
@@ -8,5 +8,11 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "RequestSizeLimits": {
+    "DefaultMaxSizeInBytes": 65536, // 64 KB
+    "Endpoints": {
+      "EmployeeController.Get": 4096 // 1 KB
+    }
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
Add middleware to create a correlation ID, used for logging and associating the request, response, and exceptions.


Closes #24 
Closes #5 